### PR TITLE
update rebase-by-default-when-doing-git-pull config recipes

### DIFF
--- a/sources/保持代码同步.md
+++ b/sources/保持代码同步.md
@@ -203,7 +203,8 @@ git pull --rebase <remote>
 事实上，使用`--rebase`的pull的工作流是如此普遍，以致于你可以直接在配置项中设置它：
 
 ``` 
-git config --global branch.autosetuprebase always
+git config --global branch.autosetuprebase always # In git < 1.7.9
+git config --global pull.rebase true              # In git >= 1.7.9
 ```
 
 在运行这个命令之后，所有的`git pull`命令将使用`git rebase,`而不是`git merge`。


### PR DESCRIPTION
According to https://coderwall.com/p/tnoiug/rebase-by-default-when-doing-git-pull

git config --global branch.autosetuprebase always

is outdated.