### PR TITLE
修改了一些错别字

### DIFF
--- a/sources/保持代码同步.md
+++ b/sources/保持代码同步.md
@@ -182,7 +182,7 @@ git pull --rebase <remote>
 
 ### 讨论
 
-你可以将 `git pull` 当做 Git 中对应 `svn update` 的命令。这是同步你本地仓库和上游更改的简单方式。下图结束了 pull 过程中的每一步。
+你可以将 `git pull` 当做 Git 中对应 `svn update` 的命令。这是同步你本地仓库和上游更改的简单方式。下图揭示了 pull 过程中的每一步。
 
 ![Git Tutorial: git pull](https://www.atlassian.com/git/images/tutorials/collaborating/syncing/03.svg)
 


### PR DESCRIPTION
有一些错误在源码上被修改了但是没有同步到wiki上。
wiki无法直接push所以我就写在这里了不知道对不对
发现两个小问题：
+ 3.2节内有一些文字中间用了<text>这样的写法，但是在markdown中会被当作HTML标签忽略，所以应该改成`<text>`的形式
+ 2.7节讲到git rebase -i这一段的时候，有一个拼写错误amendy

这两个问题在源码中都已经被解决，但是没有同步到wiki